### PR TITLE
Add support for loading tiny yolov3 pretrained weights

### DIFF
--- a/models.py
+++ b/models.py
@@ -277,6 +277,8 @@ class Darknet(nn.Module):
         cutoff = None
         if "darknet53.conv.74" in weights_path:
             cutoff = 75
+        elif "yolov3-tiny.conv.15" in weights_path:
+            cutoff = 15
 
         ptr = 0
         for i, (module_def, module) in enumerate(zip(self.module_defs, self.module_list)):


### PR DESCRIPTION
For the pretrained tiny yolov3 weight generated by original darknet
`wget https://pjreddie.com/media/files/yolov3-tiny.weights`
`./darknet partial cfg/yolov3-tiny.cfg yolov3-tiny.weights yolov3-tiny.conv.15 15`