### PR TITLE
add parameter for ListDataset class in train.py so it adjust to parse…

### DIFF
--- a/train.py
+++ b/train.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
             model.load_darknet_weights(opt.pretrained_weights)
 
     # Get dataloader
-    dataset = ListDataset(train_path, augment=True, multiscale=opt.multiscale_training)
+    dataset = ListDataset(train_path, img_size=opt.img_size, augment=True, multiscale=opt.multiscale_training)
     dataloader = torch.utils.data.DataLoader(
         dataset,
         batch_size=opt.batch_size,


### PR DESCRIPTION
`img_size=opt.img_size` was missing in `train.py`, causing bad results in validation and testing when change opt.img_size value to anything but 416 (which is the default value of `img_size` parameter in `ListDataset` class). Adding this parameter will allow user to use different input image size for training.