### PR TITLE
Remove tensorflow dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ numpy
 torch>=1.0
 torchvision
 matplotlib
-tensorflow
 tensorboard
 terminaltables
 pillow

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,17 +1,16 @@
-import tensorflow as tf
+from torch.utils.tensorboard import SummaryWriter
 
 
 class Logger(object):
     def __init__(self, log_dir):
         """Create a summary writer logging to log_dir."""
-        self.writer = tf.summary.FileWriter(log_dir)
+        self.writer = SummaryWriter(log_dir)
 
     def scalar_summary(self, tag, value, step):
         """Log a scalar variable."""
-        summary = tf.Summary(value=[tf.Summary.Value(tag=tag, simple_value=value)])
-        self.writer.add_summary(summary, step)
+        self.writer.add_scalar(tag, value, step)
 
     def list_of_scalars_summary(self, tag_value_pairs, step):
         """Log scalar variables."""
-        summary = tf.Summary(value=[tf.Summary.Value(tag=tag, simple_value=value) for tag, value in tag_value_pairs])
-        self.writer.add_summary(summary, step)
+        [self.writer.add_scalar(tag, value, step) for tag, value in tag_value_pairs]
+


### PR DESCRIPTION
This implementation is based on PyTorch and TensorFlow is sometimes a bit slow/frustrating to install. The TensorFlow dependency of this project is also only used for logging to tensorboard, but this feature is also provided by PyTorch. 
So I removed the TensorFlow dependency and rebuild the parts using the PyTorch utils.