### PR TITLE
But logs in destinct folders

### DIFF
--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,10 +1,16 @@
+import os
+import datetime
 from torch.utils.tensorboard import SummaryWriter
 
 
 class Logger(object):
-    def __init__(self, log_dir):
+    def __init__(self, log_dir, log_hist=True):
         """Create a summary writer logging to log_dir."""
-        self.writer = SummaryWriter(log_dir=log_dir)
+        if log_hist:    # Check a new folder for each log should be dreated
+            log_dir = os.path.join(
+                log_dir,
+                datetime.datetime.now().strftime("%Y_%m_%d__%H_%M_%S"))
+        self.writer = SummaryWriter(log_dir)
 
     def scalar_summary(self, tag, value, step):
         """Log a scalar variable."""


### PR DESCRIPTION
This pull request prevents tensorboard from "combining" multiple training runs into one broken graph. Instead, all runs are saved in a different folder (done via timestamp). You, therefore, can select the current and previous runs in your tensorboard without any further file interactions.