### PR TITLE
Use cfg hyperparams

### DIFF
--- a/models.py
+++ b/models.py
@@ -30,8 +30,8 @@ def create_modules(module_defs):
         'burn_in': int(hyperparams['burn_in']),
         'max_batches': int(hyperparams['max_batches']),
         'policy': hyperparams['policy'],
-        'lr_steps': zip(list(map(int,   hyperparams["steps"].split(","))), 
-                        list(map(float, hyperparams["scales"].split(","))))
+        'lr_steps': list(zip(map(int,   hyperparams["steps"].split(",")), 
+                             map(float, hyperparams["scales"].split(","))))
     })
     assert hyperparams["height"] == hyperparams["width"], \
         "Height and width should be equal! Non square images are padded with zeros."
@@ -278,6 +278,7 @@ class Darknet(nn.Module):
                 yolo_outputs.append(x)
             layer_outputs.append(x)
         yolo_outputs = to_cpu(torch.cat(yolo_outputs, 1))
+        loss = loss / self.hyperparams['batch']
         return yolo_outputs if targets is None else (loss, yolo_outputs)
 
     def load_darknet_weights(self, weights_path):

--- a/models.py
+++ b/models.py
@@ -90,8 +90,9 @@ def create_modules(module_defs):
             anchors = [anchors[i] for i in anchor_idxs]
             num_classes = int(module_def["classes"])
             img_size = int(hyperparams["height"])
+            ignore_thres = float(module_def["ignore_thresh"])
             # Define detection layer
-            yolo_layer = YOLOLayer(anchors, num_classes, img_size)
+            yolo_layer = YOLOLayer(anchors, num_classes, ignore_thres, img_size)
             modules.add_module(f"yolo_{module_i}", yolo_layer)
         # Register module list and number of output filters
         module_list.append(modules)
@@ -123,7 +124,7 @@ class EmptyLayer(nn.Module):
 class YOLOLayer(nn.Module):
     """Detection layer"""
 
-    def __init__(self, anchors, num_classes, img_dim=416):
+    def __init__(self, anchors, num_classes, ignore_thres, img_dim=416):
         super(YOLOLayer, self).__init__()
         self.anchors = anchors
         self.num_anchors = len(anchors)
@@ -132,7 +133,7 @@ class YOLOLayer(nn.Module):
         self.mse_loss = nn.MSELoss()
         self.bce_loss = nn.BCELoss()
         self.obj_scale = 1
-        self.noobj_scale = 100
+        self.noobj_scale = 0.5
         self.metrics = {}
         self.img_dim = img_dim
         self.grid_size = 0  # grid size

--- a/models.py
+++ b/models.py
@@ -33,6 +33,8 @@ def create_modules(module_defs):
         'lr_steps': zip(list(map(int,   hyperparams["steps"].split(","))), 
                         list(map(float, hyperparams["scales"].split(","))))
     })
+    assert hyperparams["height"] == hyperparams["width"], \
+        "Height and width should be equal! Non square images are padded with zeros."
     module_list = nn.ModuleList()
     for module_i, module_def in enumerate(module_defs):
         modules = nn.Sequential()

--- a/models.py
+++ b/models.py
@@ -35,6 +35,7 @@ def create_modules(module_defs):
     })
     assert hyperparams["height"] == hyperparams["width"], \
         "Height and width should be equal! Non square images are padded with zeros."
+    output_filters = [hyperparams["channels"]]
     module_list = nn.ModuleList()
     for module_i, module_def in enumerate(module_defs):
         modules = nn.Sequential()

--- a/models.py
+++ b/models.py
@@ -18,7 +18,21 @@ def create_modules(module_defs):
     Constructs module list of layer blocks from module configuration in module_defs
     """
     hyperparams = module_defs.pop(0)
-    output_filters = [int(hyperparams["channels"])]
+    hyperparams.update({
+        'batch': int(hyperparams['batch']),
+        'subdivisions': int(hyperparams['subdivisions']),
+        'width': int(hyperparams['width']),
+        'height': int(hyperparams['height']),
+        'channels': int(hyperparams['channels']),
+        'momentum': float(hyperparams['momentum']),
+        'decay': float(hyperparams['decay']),
+        'learning_rate': float(hyperparams['learning_rate']),
+        'burn_in': int(hyperparams['burn_in']),
+        'max_batches': int(hyperparams['max_batches']),
+        'policy': hyperparams['policy'],
+        'lr_steps': zip(list(map(int,   hyperparams["steps"].split(","))), 
+                        list(map(float, hyperparams["scales"].split(","))))
+    })
     module_list = nn.ModuleList()
     for module_i, module_def in enumerate(module_defs):
         modules = nn.Sequential()

--- a/train.py
+++ b/train.py
@@ -71,14 +71,18 @@ if __name__ == "__main__":
     dataset = ListDataset(train_path, multiscale=opt.multiscale_training, img_size=opt.img_size, transform=AUGMENTATION_TRANSFORMS)
     dataloader = torch.utils.data.DataLoader(
         dataset,
-        batch_size=opt.batch_size,
+        batch_size= model.hyperparams['batch'] // model.hyperparams['subdivisions'],
         shuffle=True,
         num_workers=opt.n_cpu,
         pin_memory=True,
         collate_fn=dataset.collate_fn,
     )
 
-    optimizer = torch.optim.Adam(model.parameters())
+    optimizer = torch.optim.SGD(
+        model.parameters(), 
+        lr=model.hyperparams['learning_rate'], 
+        weight_decay=model.hyperparams['decay'],
+        momentum=model.hyperparams['momentum'])
 
     metrics = [
         "grid_size",

--- a/train.py
+++ b/train.py
@@ -29,8 +29,6 @@ import torch.optim as optim
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--epochs", type=int, default=100, help="number of epochs")
-    parser.add_argument("--batch_size", type=int, default=8, help="size of each image batch")
-    parser.add_argument("--gradient_accumulations", type=int, default=2, help="number of gradient accums before step")
     parser.add_argument("--model_def", type=str, default="config/yolov3.cfg", help="path to model definition file")
     parser.add_argument("--data_config", type=str, default="config/coco.data", help="path to data config file")
     parser.add_argument("--pretrained_weights", type=str, help="if specified starts from checkpoint model")

--- a/train.py
+++ b/train.py
@@ -101,8 +101,6 @@ if __name__ == "__main__":
         "conf_noobj",
     ]
 
-    step = 0
-
     for epoch in range(opt.epochs):
         model.train()
         start_time = time.time()
@@ -120,23 +118,19 @@ if __name__ == "__main__":
             ###############
 
             if batches_done % model.hyperparams['subdivisions'] == 0:
-                # Calculate the current step
-                step += model.hyperparams['batch']
-
                 # Adapt learning rate
                 # Get learning rate defined in cfg
                 lr = model.hyperparams['learning_rate']
-
-                if step < model.hyperparams['burn_in']:
+                if batches_done < model.hyperparams['burn_in']:
                     # Burn in
-                    lr *= (step / model.hyperparams['burn_in'])
+                    lr *= (batches_done / model.hyperparams['burn_in'])
                 else:
                     # Set and parse the learning rate to the steps defined in the cfg
                     for threshold, value in model.hyperparams['lr_steps']:
-                        if step > threshold:
+                        if batches_done > threshold:
                             lr *= value
                 # Log the learning rate
-                logger.scalar_summary("learning_rate", lr, step)
+                logger.scalar_summary("learning_rate", lr, batches_done)
                 # Set learning rate
                 for g in optimizer.param_groups:
                         g['lr'] = lr
@@ -172,7 +166,7 @@ if __name__ == "__main__":
                     if name != "grid_size":
                         tensorboard_log += [(f"train/{name}_{j+1}", metric)]
             tensorboard_log += [("train/loss", to_cpu(loss).item())]
-            logger.list_of_scalars_summary(tensorboard_log, step)
+            logger.list_of_scalars_summary(tensorboard_log, batches_done)
 
             # Determine approximate time left for epoch
             epoch_batches_left = len(dataloader) - (batch_i + 1)


### PR DESCRIPTION
This includes using SGD instead of ADAM, removing the `batch_size` and `gradient_accumulations` from the cli and using nearly all params described in the `.cfg` for the training.