### PR TITLE
Make it work for uppercase suffixes of image files

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -6,6 +6,7 @@ import warnings
 import numpy as np
 from PIL import Image
 from PIL import ImageFile
+import re
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
@@ -67,10 +68,12 @@ class ListDataset(Dataset):
         with open(list_path, "r") as file:
             self.img_files = file.readlines()
 
-        self.label_files = [
-            path.replace("images", "labels").replace(".png", ".txt").replace(".jpg", ".txt")
-            for path in self.img_files
-        ]
+        self.label_files = []
+        for path in self.img_files:
+            label_file = path.replace("images", "labels")
+            label_file = re.compile(re.escape('png'), re.IGNORECASE).sub('txt', label_file)
+            label_file = re.compile(re.escape('jpg'), re.IGNORECASE).sub('txt', label_file)
+            self.label_files.append(label_file)
 
         self.img_size = img_size
         self.max_objects = 100

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -6,7 +6,6 @@ import warnings
 import numpy as np
 from PIL import Image
 from PIL import ImageFile
-import re
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
@@ -70,9 +69,9 @@ class ListDataset(Dataset):
 
         self.label_files = []
         for path in self.img_files:
-            label_file = path.replace("images", "labels")
-            label_file = re.compile(re.escape('png'), re.IGNORECASE).sub('txt', label_file)
-            label_file = re.compile(re.escape('jpg'), re.IGNORECASE).sub('txt', label_file)
+            label_file = os.path.join(os.path.split(os.path.dirname(path))[0], 'labels')
+            label_file = os.path.join(label_file, os.path.basename(path))
+            label_file = os.path.splitext(label_file)[0] + '.txt'
             self.label_files.append(label_file)
 
         self.img_size = img_size


### PR DESCRIPTION
I tried to train a model using my custom dataset which was annotated with [cvat](https://github.com/openvinotoolkit/cvat) .

I got an error due to uppercases "PNG" of my image files.
 (The image files had been generated by cvat.)

```
Could not read label 'data/custom/labels/frame_003400.PNG'.
Could not read label 'data/custom/labels/frame_000600.PNG'.
Could not read label 'data/custom/labels/frame_003700.PNG'.
Training Epoch 0:   0%|                                                                                             | 0/6 [00:02<?, ?it/s]
Traceback (most recent call last):
  File "train.py", line 105, in <module>
    for batch_i, (_, imgs, targets) in enumerate(tqdm.tqdm(dataloader, desc=f"Training Epoch {epoch}")):
  File "/Users/Hiroshi.Nishigami/work/PyTorch-YOLOv3/.venv/lib/python3.8/site-packages/tqdm/std.py", line 1178, in __iter__
Could not read label 'data/custom/labels/frame_003300.PNG'.
Could not read label 'data/custom/labels/frame_000800.PNG'.
Could not read label 'data/custom/labels/frame_000700.PNG'.
    for obj in iterable:
  File "/Users/Hiroshi.Nishigami/work/PyTorch-YOLOv3/.venv/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 517, in __next__
Could not read label 'data/custom/labels/frame_003200.PNG'.
    data = self._next_data()
  File "/Users/Hiroshi.Nishigami/work/PyTorch-YOLOv3/.venv/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 1199, in _next_data
    return self._process_data(data)
  File "/Users/Hiroshi.Nishigami/work/PyTorch-YOLOv3/.venv/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 1225, in _process_data
    data.reraise()
  File "/Users/Hiroshi.Nishigami/work/PyTorch-YOLOv3/.venv/lib/python3.8/site-packages/torch/_utils.py", line 429, in reraise
    raise self.exc_type(msg)
ValueError: Caught ValueError in DataLoader worker process 0.
Original Traceback (most recent call last):
  File "/Users/Hiroshi.Nishigami/work/PyTorch-YOLOv3/.venv/lib/python3.8/site-packages/torch/utils/data/_utils/worker.py", line 202, in _worker_loop
    data = fetcher.fetch(index)
  File "/Users/Hiroshi.Nishigami/work/PyTorch-YOLOv3/.venv/lib/python3.8/site-packages/torch/utils/data/_utils/fetch.py", line 47, in fetch
    return self.collate_fn(data)
  File "/Users/Hiroshi.Nishigami/work/PyTorch-YOLOv3/utils/datasets.py", line 129, in collate_fn
    paths, imgs, bb_targets = list(zip(*batch))
ValueError: not enough values to unpack (expected 3, got 0)
```