### PR TITLE
add deterministic training

### DIFF
--- a/pytorchyolo/train.py
+++ b/pytorchyolo/train.py
@@ -12,7 +12,7 @@ import torch.optim as optim
 
 from pytorchyolo.models import load_model
 from pytorchyolo.utils.logger import Logger
-from pytorchyolo.utils.utils import to_cpu, load_classes, print_environment_info
+from pytorchyolo.utils.utils import to_cpu, load_classes, print_environment_info, provide_determinism, worker_seed_np
 from pytorchyolo.utils.datasets import ListDataset
 from pytorchyolo.utils.augmentations import AUGMENTATION_TRANSFORMS
 # from pytorchyolo.utils.transforms import DEFAULT_TRANSFORMS
@@ -52,7 +52,8 @@ def _create_data_loader(img_path, batch_size, img_size, n_cpu, multiscale_traini
         shuffle=True,
         num_workers=n_cpu,
         pin_memory=True,
-        collate_fn=dataset.collate_fn)
+        collate_fn=dataset.collate_fn,
+        worker_init_fn=worker_seed_np)
     return dataloader
 
 
@@ -72,8 +73,12 @@ def run():
     parser.add_argument("--conf_thres", type=float, default=0.1, help="Evaluation: Object confidence threshold")
     parser.add_argument("--nms_thres", type=float, default=0.5, help="Evaluation: IOU threshold for non-maximum suppression")
     parser.add_argument("--logdir", type=str, default="logs", help="Directory for training log files (e.g. for TensorBoard)")
+    parser.add_argument("--seed", type=int, default=42, help="Makes results reproducable. Set -1 to disable.")
     args = parser.parse_args()
     print(f"Command line arguments: {args}")
+
+    if args.seed != -1:
+        provide_determinism(args.seed)
 
     logger = Logger(args.logdir)  # Tensorboard logger
 

--- a/pytorchyolo/train.py
+++ b/pytorchyolo/train.py
@@ -12,7 +12,7 @@ import torch.optim as optim
 
 from pytorchyolo.models import load_model
 from pytorchyolo.utils.logger import Logger
-from pytorchyolo.utils.utils import to_cpu, load_classes, print_environment_info, provide_determinism, worker_seed_np
+from pytorchyolo.utils.utils import to_cpu, load_classes, print_environment_info, provide_determinism, worker_seed_set
 from pytorchyolo.utils.datasets import ListDataset
 from pytorchyolo.utils.augmentations import AUGMENTATION_TRANSFORMS
 # from pytorchyolo.utils.transforms import DEFAULT_TRANSFORMS
@@ -53,7 +53,7 @@ def _create_data_loader(img_path, batch_size, img_size, n_cpu, multiscale_traini
         num_workers=n_cpu,
         pin_memory=True,
         collate_fn=dataset.collate_fn,
-        worker_init_fn=worker_seed_np)
+        worker_init_fn=worker_seed_set)
     return dataloader
 
 
@@ -73,7 +73,7 @@ def run():
     parser.add_argument("--conf_thres", type=float, default=0.1, help="Evaluation: Object confidence threshold")
     parser.add_argument("--nms_thres", type=float, default=0.5, help="Evaluation: IOU threshold for non-maximum suppression")
     parser.add_argument("--logdir", type=str, default="logs", help="Directory for training log files (e.g. for TensorBoard)")
-    parser.add_argument("--seed", type=int, default=42, help="Makes results reproducable. Set -1 to disable.")
+    parser.add_argument("--seed", type=int, default=-1, help="Makes results reproducable. Set -1 to disable.")
     args = parser.parse_args()
     print(f"Command line arguments: {args}")
 

--- a/pytorchyolo/utils/utils.py
+++ b/pytorchyolo/utils/utils.py
@@ -21,7 +21,7 @@ def provide_determinism(seed=42):
     torch.backends.cudnn.benchmark = False
     torch.backends.cudnn.deterministic = True
 
-def worker_seed_np(worker_id):
+def worker_seed_set(worker_id):
     # See for details of numpy:
     # https://github.com/pytorch/pytorch/issues/5059#issuecomment-817392562
     # See for details of random:

--- a/pytorchyolo/utils/utils.py
+++ b/pytorchyolo/utils/utils.py
@@ -9,6 +9,32 @@ import torch.nn as nn
 import torchvision
 import numpy as np
 import subprocess
+import random
+
+
+def provide_determinism(seed=42):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    torch.backends.cudnn.benchmark = False
+    torch.backends.cudnn.deterministic = True
+
+def worker_seed_np(worker_id):
+    # See for details of numpy:
+    # https://github.com/pytorch/pytorch/issues/5059#issuecomment-817392562
+    # See for details of random:
+    # https://pytorch.org/docs/stable/notes/randomness.html#dataloader
+
+    # NumPy
+    uint64_seed = torch.initial_seed()
+    ss = np.random.SeedSequence([uint64_seed])
+    np.random.seed(ss.generate_state(4))
+
+    # random
+    worker_seed = torch.initial_seed() % 2**32
+    random.seed(worker_seed)
 
 
 def to_cpu(tensor):


### PR DESCRIPTION
## Proposed changes
I implemented a function that provides necessary settings for deterministic usage of PyTorch, NumPy and random. I added a seed argument to the `train.py` file and called it.
Since augmentations use imgaug, which uses NumPy, DataLoader of PyTorch can not provide determinism. So, I also implemented a worker_init_fn to pass to DataLoaders when determinism is desired.

Postscriptum: I think the worker_init function can be given both in deterministic case and indeterministic case. In indeterministic case, it still helps with correcting the NumPy seeds. So, I did not put any checks there.

## Related issues
https://github.com/eriklindernoren/PyTorch-YOLOv3/issues/673