### PR TITLE
Add grouped routings used by yolov4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "PyTorchYolo"
-version = "1.2.2"
+version = "1.3.2"
 readme = "README.md"
 repository = "https://github.com/eriklindernoren/PyTorch-YOLOv3"
 description = "Minimal PyTorch implementation of YOLO"


### PR DESCRIPTION
## Proposed changes
Adds the ability to add groups that split the output of the routing layer.

## Necessary checks
- [x] Update poetry package version [semantically](https://semver.org/)
- [x] Write documentation,
- [x] Test on your machine
