### PR TITLE
start epochs at 1

### DIFF
--- a/pytorchyolo/train.py
+++ b/pytorchyolo/train.py
@@ -145,7 +145,10 @@ def run():
     else:
         print("Unknown optimizer. Please choose between (adam, sgd).")
 
-    for epoch in range(args.epochs):
+    # skip epoch zero, because then the calculations for when to evaluate/checkpoint makes more intuitive sense
+    # e.g. when you stop after 30 epochs and evaluate every 10 epochs then the evaluations happen after: 10,20,30
+    # instead of: 0, 10, 20
+    for epoch in range(1, args.epochs+1):
 
         print("\n---- Training Model ----")
 


### PR DESCRIPTION
this improves the intuitive understanding for when evaluations happen/checkpoints are saved
As this might break someones workflow and is not critical, this should probably not be merged until the next major version.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->
skip epoch zero, because then the calculations for when to evaluate/checkpoint makes more intuitive sense
e.g. when you stop after 30 epochs and evaluate every 10 epochs then the evaluations happen after: 10,20,30
instead of: 0, 10, 20

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update poetry package version [semantically](https://semver.org/)
- [X] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
