### PR TITLE
Lock setuptools version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,15 @@ jobs:
 
       - name: Upgrade pip
         run: python3 -m pip install --upgrade pip
-
+      
       - name: Install Poetry
         run: pip3 install poetry --user
 
       - name: Install Dependencies
         run: poetry install
+
+      - name: Pin setup tools (remove for next torch release)
+        run: poetry run pip install setuptools==59.5.0
 
       # Prints the help pages of all scripts to see if the imports etc. work
       - name: Test the help pages

--- a/poetry.lock
+++ b/poetry.lock
@@ -614,7 +614,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.2"
-content-hash = "135097a07abab5a68f2b99b43914daf3acfb09341461632705143ba5f130d831"
+content-hash = "f4ec2f40adb919ec07e6de39051a70ca5826ee8ee596d805412f2ccb6dcf0ceb"
 
 [metadata.files]
 absl-py = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -614,7 +614,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.2"
-content-hash = "f4ec2f40adb919ec07e6de39051a70ca5826ee8ee596d805412f2ccb6dcf0ceb"
+content-hash = "135097a07abab5a68f2b99b43914daf3acfb09341461632705143ba5f130d831"
 
 [metadata.files]
 absl-py = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ Pillow = "^8.1.0"
 tqdm = "^4.55.1"
 imgaug = "^0.4.0"
 torchsummary = "^1.5.1"
-setuptools = "59.5.0"
 
 [tool.poetry.dev-dependencies]
 profilehooks = "^1.12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ Pillow = "^8.1.0"
 tqdm = "^4.55.1"
 imgaug = "^0.4.0"
 torchsummary = "^1.5.1"
+setuptools = "59.5.0"
 
 [tool.poetry.dev-dependencies]
 profilehooks = "^1.12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "PyTorchYolo"
-version = "1.6.1"
+version = "1.6.2"
 readme = "README.md"
 repository = "https://github.com/eriklindernoren/PyTorch-YOLOv3"
 description = "Minimal PyTorch implementation of YOLO"


### PR DESCRIPTION
## Proposed changes
- Locks setup tools version as described in https://discuss.pytorch.org/t/import-summarywriter-gives-attributeerror-attributeerror-module-setuptools-distutils-has-no-attribute-version/140023

## Necessary checks
- [x] Update poetry package version [semantically](https://semver.org/)
- [x] Test on your machine
