### PR TITLE
Fixed reproducibility issue related to imgaug

### DIFF
--- a/pytorchyolo/utils/utils.py
+++ b/pytorchyolo/utils/utils.py
@@ -9,6 +9,7 @@ import torchvision
 import numpy as np
 import subprocess
 import random
+import imgaug as ia
 
 
 def provide_determinism(seed=42):
@@ -16,9 +17,11 @@ def provide_determinism(seed=42):
     np.random.seed(seed)
     torch.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
+    ia.seed(seed)
 
     torch.backends.cudnn.benchmark = False
     torch.backends.cudnn.deterministic = True
+
 
 def worker_seed_set(worker_id):
     # See for details of numpy:


### PR DESCRIPTION
Even after setting a seed, PyTorch-YOLOv3 would not generate
reproducible results. This issue was caused by imgaug when
PyTorch-YOLOv3 performs image augmentation.

To fix it, I just added the line 'ia.seed(seed)' to the
function provide_determinism() at utils/utils.py. By doing
so, results obtained with PyTorch-YOLOv3 are now completely
reproducible.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update poetry package version [semantically](https://semver.org/)
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
