### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Run the commands below to create a custom model definition, replacing `<num-clas
 
 ```bash
 cd config 
-./config/create_custom_model.sh <num-classes>  # Will create custom model 'yolov3-custom.cfg'
+./create_custom_model.sh <num-classes>  # Will create custom model 'yolov3-custom.cfg'
 ```
 
 #### Classes

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ You can adjust the log directory using `--logdir <path>` when running `tensorboa
 Run the commands below to create a custom model definition, replacing `<num-classes>` with the number of classes in your dataset.
 
 ```bash
+cd config 
 ./config/create_custom_model.sh <num-classes>  # Will create custom model 'yolov3-custom.cfg'
 ```
 


### PR DESCRIPTION
Found this when I tried to use this and after using the create command the model is being saved outside the config dir.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->
added an additional command to ensure the model is being created in the config directory. Previously 

```bash
./config/createmodel.sh 
```

uses `config` dir but does not save the created model there, I think this resolves the issue when the train command is used.

``` bash
 poetry run yolo-train --model config/yolov3-custom.cfg --data config/custom.data
```

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [x] Write documentation
- [x] Test on your machine
- [ ] Create issues for future work
- [ ] Update poetry package version [semantically](https://semver.org/)
